### PR TITLE
Editing publish workflow for protecting main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     types:
       - labeled
+
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
@@ -13,6 +14,8 @@ jobs:
 
       - name: Set up git
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
 
       - name: Pull bottles
         env:
@@ -27,6 +30,7 @@ jobs:
         with:
           token: ${{ github.token }}
           branch: main
+          force: true
 
       - name: Delete branch
         if: github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
Use BrewTestBot username for automatic actions, but still authenticated via the user's token that created the label.

With main now protected, this action needs to force-with-lease push to main - only repo can close out PRs by applying the "pr-pull" label.